### PR TITLE
Add yamlschema endpoint link

### DIFF
--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -2104,6 +2104,9 @@ Learn more about [conditions](process/conditions.md?tabs=yaml),
 Syntax highlighting is available for the pipeline schema via a Visual Studio Code extension.
 You can [download Visual Studio Code](https://code.visualstudio.com), [install the extension](https://marketplace.visualstudio.com/items?itemName=ms-azure-devops.azure-pipelines), and [check out the project on GitHub](https://github.com/Microsoft/azure-pipelines-vscode).
 The extension includes a [JSON schema](https://github.com/microsoft/azure-pipelines-vscode/blob/master/service-schema.json) for validation.
-<!-- For people who get here by searching for, say, "azure pipelines template YAML schema",
+
+You can also obtain a schema that's specific to your organization (i.e. contains installed custom tasks) from [DevOps REST API's yamlschema endpoint](https://docs.microsoft.com/en-us/rest/api/azure/devops/distributedtask/yamlschema/get?view=azure-devops-rest-5.1).
+
+<!-- For people who get here by searching for, say, "azure pipelines template YAML schema", 
      look around a bit, and then type "Ctrl-F JSON" when they don't see anything promising
      in the first few screenfuls. -->


### PR DESCRIPTION
For people that are searching for 'azure pipelines template YAML schema', show a way to obtain latest schema. 
Fixes #8248.
